### PR TITLE
documentation and enable username to display in cupsd.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,29 @@ or...
 ```sh
 oc port-forward $(oc get pods -n cups -o name) -n cups 6631:6631
 ```
+
+## CUPS Printer Drivers and Configurations.
+
+A typical CUPS install provides printer drivers dynamically by using a driver information file (.drv) and creating a PPD driver file that can be used by CUPS printers. By default, when a printer is configured in CUPS, the PPD driver is saved to the /etc/cups/ppd/ directory, and the printer definition is added to the /etc/cups/printers.conf file. The printers.conf file can hold information for more than one printer and required PPD files can be added to the /etc/cups/ppd/ directory.
+
+If the printer configurations (/etc/cups/printers.conf) and drivers (/etc/cups/ppd/) that are required are known these can be included in builds.
+
+## Sending Test Print Jobs
+
+To test printing from the command line, you can use the lp command which is provided from the cups-client.rpm
+To send a test print job from the command line of a client:
+```sh
+echo "Test Message Content" | lp -d printer_name
+```
+Or,
+```sh
+lp -d printer_name /path/to/file
+```
+
+Cups provides test files in the /usr/share/cups/data/ directory.
+You can add a different job name by using the -t (title) option with a messages:
+```sh
+lp -d printer_name -t "Print Job XYZ" /usr/share/cups/data/default-testpage.pdf
+```
+
+Finally, from the CUPS UI, select a printer and then in the Maintenance drop down list select "Print Test Page"

--- a/helm/cups/templates/configmap-cupsd.conf.yaml
+++ b/helm/cups/templates/configmap-cupsd.conf.yaml
@@ -167,7 +167,7 @@ data:
     <Policy kerberos>
       # Job/subscription privacy...
       JobPrivateAccess default
-      JobPrivateValues default
+      JobPrivateValues none
       SubscriptionPrivateAccess default
       SubscriptionPrivateValues default
 


### PR DESCRIPTION
Added some test commands and changed the cupsd.conf template to allow job-name, job-originating-host-name, job-originating-user-name, and phone to display in CUPS UI for print jobs. This is controlled from the following line in the file:
JobPrivateValues none 