### PR TITLE
Fix cupsd conf

### DIFF
--- a/helm/cups/templates/configmap-cupsd.conf.yaml
+++ b/helm/cups/templates/configmap-cupsd.conf.yaml
@@ -77,7 +77,7 @@ data:
     <Policy default>
       # Job/subscription privacy...
       JobPrivateAccess default
-      JobPrivateValues default
+      JobPrivateValues none
       SubscriptionPrivateAccess default
       SubscriptionPrivateValues default
 
@@ -168,7 +168,7 @@ data:
     <Policy kerberos>
       # Job/subscription privacy...
       JobPrivateAccess default
-      JobPrivateValues none
+      JobPrivateValues default
       SubscriptionPrivateAccess default
       SubscriptionPrivateValues default
 


### PR DESCRIPTION
correcting the JobPrivateAccess none on the correct line in the config file. Restored line 171 to original value and changed on line 80.  This setting allows usernames and other information to display on submitted CUPS print jobs and I originally changed the wrong line.