### PR TITLE
Script to run lpadmin to add printers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@ FROM registry.redhat.io/rhel9/cups:latest
 
 USER root
 
-RUN curl -s -o /etc/cups/ppd/Lexmark_M5200_Series.ppd https://www.openprinting.org/download/PPD/Lexmark/Lexmark_M5200_Series.ppd && \
-    chown -R cups:lp /etc/cups/ppd/
+RUN curl -s -o /usr/share/ppd/Lexmark_M5200_Series.ppd https://www.openprinting.org/download/PPD/Lexmark/Lexmark_M5200_Series.ppd
 
 USER cups

--- a/helm/cups/scripts/lpadmin.sh
+++ b/helm/cups/scripts/lpadmin.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+lpadmin -p test-script -v socket://10.44.12.250:9100 -m drv:///sample.drv/generic.ppd -o printer-is-shared=true -D "Test lpadmin" -E -L "Test Location"
+lpadmin -p MX123 -v socket://10.44.12.250:9100 -m drv:///sample.drv/generic.ppd -o printer-is-shared=true -D "Test lpadmin" -E -L "Test Location"

--- a/helm/cups/templates/configmap-cups-conf.yaml
+++ b/helm/cups/templates/configmap-cups-conf.yaml
@@ -1,5 +1,4 @@
 ﻿{{- $cupsd := .Values.config.cupsd | required ".Values.config.cupsd must be defined. Set the value from respective files specified via the helm command line with --set-file=config.cupsd=<somefolder>/cupsd.conf" }}
-{{- $printers := .Values.config.printers | required ".Values.config.printers must be defined. Set the value from respective files specified via the helm command line with --set-file=config.printers=<somefolder>/printers.conf" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -7,5 +6,3 @@ metadata:
 data:
   cupsd.conf: |
     {{- $cupsd | nindent 4 }}
-  printers.conf: |
-    {{- $printers | nindent 4 }}

--- a/helm/cups/templates/configmap-run-lpadmin.yaml
+++ b/helm/cups/templates/configmap-run-lpadmin.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: run-lpadmin
+data:
+{{ (.Files.Glob "scripts/lpadmin.sh").AsConfig | indent 2 }}

--- a/helm/cups/templates/statefulsets.yaml
+++ b/helm/cups/templates/statefulsets.yaml
@@ -41,16 +41,23 @@ spec:
       initContainers:
         - name: cupsd-conf
           image: registry.access.redhat.com/ubi9/ubi-minimal
-          command: ["sh", "-c", "cp /tmp/cupsd.conf /etc/cups/cupsd.conf && chmod 0660 /etc/cups/cupsd.conf && chown 1000:7 /etc/cups/cupsd.conf && cp /tmp/printers.conf /etc/cups/printers.conf && chmod 0660 /etc/cups/printers.conf && chown 1000:7 /etc/cups/printers.conf"]
+          command: ["sh", "-c", "cp /tmp/cupsd.conf /etc/cups/cupsd.conf && chmod 0660 /etc/cups/cupsd.conf && chown 1000:7 /etc/cups/cupsd.conf"]
+          # command: ["sh", "-c", "cp /tmp/cupsd.conf /etc/cups/cupsd.conf && chmod 0660 /etc/cups/cupsd.conf && chown 1000:7 /etc/cups/cupsd.conf && cp /tmp/printers.conf /etc/cups/printers.conf && chmod 0660 /etc/cups/printers.conf && chown 1000:7 /etc/cups/printers.conf"]
+          # command: ["sh", "-c", "cp /tmp/cupsd.conf /etc/cups/cupsd.conf && chmod 0660 /etc/cups/cupsd.conf && chown 1000:7 /etc/cups/cupsd.conf && cp /tmp/printers.conf /etc/cups/printers.conf && chmod 0660 /etc/cups/printers.conf && chown 1000:7 /etc/cups/printers.conf && cp /tmp/default.ppd /etc/cups/ppd/default.ppd && chmod 0660 /etc/cups/ppd/default.ppd && chown 1000:7 /etc/cups/ppd/default.ppd"]
           volumeMounts:
             - name: cupsd-conf
               mountPath: /tmp/cupsd.conf
               subPath: cupsd.conf
-            - name: cupsd-conf
-              mountPath: /tmp/printers.conf
-              subPath: printers.conf
+            # - name: cupsd-conf
+            #   mountPath: /tmp/printers.conf
+            #   subPath: printers.conf
+            # - name: cupsd-conf
+            #   mountPath: /tmp/default.ppd
+            #   subPath: default.ppd
             - name: empty
               mountPath: /etc/cups/
+            # - name: empty-ppd
+            #   mountPath: /etc/cups/ppd/
       containers:
         - name: {{ $.Chart.Name }}
           securityContext:
@@ -65,13 +72,22 @@ spec:
           resources:
             {{- toYaml $.Values.resources | nindent 12 }}
           {{- end }}
-          volumeMounts:
+          lifecycle: 
+            postStart: 
+              exec: 
+                command: ["/bin/bash", "-c", "/scripts-dir/lpadmin.sh"]
+          volumeMounts: 
+            - name: run-script
+              mountPath: /scripts-dir
             - name: empty
               mountPath: /etc/cups/cupsd.conf
               subPath: cupsd.conf
-            - name: empty
-              mountPath: /etc/cups/printers.conf
-              subPath: printers.conf
+            # - name: empty
+            #   mountPath: /etc/cups/printers.conf
+            #   subPath: printers.conf
+            # - name: empty-ppd
+            #   mountPath: /etc/cups/ppd/default.ppd
+            #   subPath: default.ppd
             - name: print-jobs
               mountPath: /var/spool/cups
       {{- with $.Values.nodeSelector }}
@@ -101,6 +117,10 @@ spec:
             defaultMode: 0777
         - name: empty
           emptyDir: {}
+        - name: run-script
+          configMap: 
+            name: run-lpadmin
+            defaultMode: 0777
   volumeClaimTemplates:
   - metadata:
       name: print-jobs

--- a/helm/cups/templates/statefulsets.yaml
+++ b/helm/cups/templates/statefulsets.yaml
@@ -42,22 +42,12 @@ spec:
         - name: cupsd-conf
           image: registry.access.redhat.com/ubi9/ubi-minimal
           command: ["sh", "-c", "cp /tmp/cupsd.conf /etc/cups/cupsd.conf && chmod 0660 /etc/cups/cupsd.conf && chown 1000:7 /etc/cups/cupsd.conf"]
-          # command: ["sh", "-c", "cp /tmp/cupsd.conf /etc/cups/cupsd.conf && chmod 0660 /etc/cups/cupsd.conf && chown 1000:7 /etc/cups/cupsd.conf && cp /tmp/printers.conf /etc/cups/printers.conf && chmod 0660 /etc/cups/printers.conf && chown 1000:7 /etc/cups/printers.conf"]
-          # command: ["sh", "-c", "cp /tmp/cupsd.conf /etc/cups/cupsd.conf && chmod 0660 /etc/cups/cupsd.conf && chown 1000:7 /etc/cups/cupsd.conf && cp /tmp/printers.conf /etc/cups/printers.conf && chmod 0660 /etc/cups/printers.conf && chown 1000:7 /etc/cups/printers.conf && cp /tmp/default.ppd /etc/cups/ppd/default.ppd && chmod 0660 /etc/cups/ppd/default.ppd && chown 1000:7 /etc/cups/ppd/default.ppd"]
           volumeMounts:
             - name: cupsd-conf
               mountPath: /tmp/cupsd.conf
               subPath: cupsd.conf
-            # - name: cupsd-conf
-            #   mountPath: /tmp/printers.conf
-            #   subPath: printers.conf
-            # - name: cupsd-conf
-            #   mountPath: /tmp/default.ppd
-            #   subPath: default.ppd
             - name: empty
               mountPath: /etc/cups/
-            # - name: empty-ppd
-            #   mountPath: /etc/cups/ppd/
       containers:
         - name: {{ $.Chart.Name }}
           securityContext:
@@ -82,12 +72,6 @@ spec:
             - name: empty
               mountPath: /etc/cups/cupsd.conf
               subPath: cupsd.conf
-            # - name: empty
-            #   mountPath: /etc/cups/printers.conf
-            #   subPath: printers.conf
-            # - name: empty-ppd
-            #   mountPath: /etc/cups/ppd/default.ppd
-            #   subPath: default.ppd
             - name: print-jobs
               mountPath: /var/spool/cups
       {{- with $.Values.nodeSelector }}

--- a/helm/cups/values.yaml
+++ b/helm/cups/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: quay.io/wuzeng/test-cups
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "latest"
+  tag: "v2"
 
 imagePullSecrets: []
 nameOverride: ""
@@ -86,7 +86,7 @@ openshift:
 # Set these values from respective files specified via the helm command line with --set-file
 config:
   cupsd:
-  printers:
+
 
 # global pvc size for all statefulsets
 volumeClaimTemplate:

--- a/helm/cups/values.yaml
+++ b/helm/cups/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: quay.io/wuzeng/test-cups
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "v2"
+  tag: "latest"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
Leaving out printers.conf and using a script to run lpadmin commands to add printers instead. The reason being the ppd files for the printers defined in printers.conf are also needed in order for the printer config to persist. 
